### PR TITLE
Upgrade to golang v1.20

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ build:
 
 requirements:
   build:
-    - {{ compiler('go') }} 1.18
+    - {{ compiler('go') }} 1.20
 
 test:
   requires:


### PR DESCRIPTION
@sodre I suspect CI is failing because of the golang version needs to be upgraded.  Requesting review/merge.